### PR TITLE
Add function that renders blaze HTML to a list of Nodes

### DIFF
--- a/src/Text/Blaze/Renderer/XmlHtml.hs
+++ b/src/Text/Blaze/Renderer/XmlHtml.hs
@@ -7,7 +7,7 @@
 -- @string@. This also applies to the functions @preEscapedText@,
 -- @preEscapedTextValue@...
 --
-module Text.Blaze.Renderer.XmlHtml (renderHtml) where
+module Text.Blaze.Renderer.XmlHtml (renderHtml, renderHtml_) where
 
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -74,3 +74,7 @@ renderHtml :: Html -> Document
 renderHtml html = HtmlDocument UTF8 Nothing (renderNodes html [])
 {-# INLINE renderHtml #-}
 
+-- | Render HTML to a list of xmlhtml nodes
+--
+renderHtml_ :: Html -> [Node]
+renderHtml_ = flip renderNodes []


### PR DESCRIPTION
When [using blaze-html in splices](http://softwaresimply.blogspot.com/2010/12/heist-gets-blaze-syntax.html) with snap 0.4, I felt the need of that function.  Not sure so, if `renderHtml_` is a good name.  Btw. for what do we need `renderHtml`?
