### PR TITLE
Bumping minimal reuquired parsec version to 3.1.2

### DIFF
--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -823,7 +823,7 @@ Library
                        blaze-html           >= 0.3.2 && < 0.5,
                        bytestring           >= 0.9   && < 0.10,
                        containers           >= 0.3   && < 0.5,
-                       parsec               >= 3.1   && < 3.2,
+                       parsec               >= 3.1.2 && < 3.2,
                        text                 >= 0.11  && < 0.12,
                        unordered-containers >= 0.1.4 && < 0.2
 


### PR DESCRIPTION
Sorry, the Text.Parsec.Text was introduced in 3.1.2, not 3.1.
