### PR TITLE
Added and exposed renderFragment function that renders an XML document fragment.

### DIFF
--- a/src/Text/XmlHtml.hs
+++ b/src/Text/XmlHtml.hs
@@ -56,7 +56,8 @@ module Text.XmlHtml (
     parseHTML,
 
     -- * Rendering
-    render
+    render,
+    XML.renderFragment
     ) where
 
 ------------------------------------------------------------------------------

--- a/src/Text/XmlHtml/XML/Render.hs
+++ b/src/Text/XmlHtml/XML/Render.hs
@@ -24,6 +24,11 @@ render e dt ns = byteOrder
                 | otherwise = firstNode e (head ns)
                     `mappend` (mconcat $ map (node e) (tail ns))
 
+------------------------------------------------------------------------------
+renderFragment :: Encoding -> [Node] -> Builder
+renderFragment _ []     = mempty
+renderFragment e (n:ns) = firstNode e n `mappend` (mconcat $ map (node e) ns)
+
 
 ------------------------------------------------------------------------------
 xmlDecl :: Encoding -> Builder

--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -1,5 +1,5 @@
 Name:                xmlhtml
-Version:             0.1.6.2
+Version:             0.1.7
 Synopsis:            XML parser and renderer with HTML 5 quirks mode
 Description:         Contains renderers and parsers for both XML and HTML 5
                      document fragments, which share data structures wo that


### PR DESCRIPTION
Hey guys,

Currently we are using xmlhtml in our project and although we really like the package we needed a function that wasn't directly exposed in your interface. We would like to be able to render XML fragments without any declarations or byte-order mark, just a plain fragment.

If you think this might be a useful addition please merge, if not maybe you know a better way to achieve this.

Thanks,
Sebastiaan
