### PR TITLE
Fix ambiquity due to generalised `elem`

### DIFF
--- a/src/Text/XmlHtml/HTML/Parse.hs
+++ b/src/Text/XmlHtml/HTML/Parse.hs
@@ -198,7 +198,7 @@ emptyOrStartTag = do
 ------------------------------------------------------------------------------
 attrName :: Parser Text
 attrName = takeWhile1 isAttrName
-  where isAttrName c | c `elem` "\0 \"\'>/=" = False
+  where isAttrName c | c `elem` ['\0',' ','"','\'','>','/','='] = False
                      | isControlChar c       = False
                      | otherwise             = True
 
@@ -216,15 +216,15 @@ isControlChar c | c >= '\x007F' && c <= '\x009F' = True
 quotedAttrValue :: Parser Text
 quotedAttrValue = singleQuoted <|> doubleQuoted
   where
-    singleQuoted = P.char '\'' *> refTill "&\'" <* P.char '\''
-    doubleQuoted = P.char '\"' *> refTill "&\"" <* P.char '\"'
+    singleQuoted = P.char '\'' *> refTill ['&','\''] <* P.char '\''
+    doubleQuoted = P.char '"'  *> refTill ['&','"']  <* P.char '"'
     refTill end = T.concat <$> many
         (takeWhile1 (not . (`elem` end)) <|> reference)
 
 
 ------------------------------------------------------------------------------
 unquotedAttrValue :: Parser Text
-unquotedAttrValue = refTill " \"\'=<>&`"
+unquotedAttrValue = refTill [' ','"','\'','=','<','>','&','`']
   where
     refTill end = T.concat <$> some
         (takeWhile1 (not . (`elem` end)) <|> reference)

--- a/src/Text/XmlHtml/XML/Parse.hs
+++ b/src/Text/XmlHtml/XML/Parse.hs
@@ -138,7 +138,7 @@ docFragment e = do
 
 ------------------------------------------------------------------------------
 whiteSpace :: Parser ()
-whiteSpace = some (P.satisfy (`elem` " \t\r\n")) *> return ()
+whiteSpace = some (P.satisfy (`elem` [' ','\t','\r','\n'])) *> return ()
 
 
 ------------------------------------------------------------------------------
@@ -186,8 +186,8 @@ name = do
 attrValue :: Parser Text
 attrValue = fmap T.concat (singleQuoted <|> doubleQuoted)
   where
-    singleQuoted = P.char '\'' *> refTill "<&\'" <* P.char '\''
-    doubleQuoted = P.char '\"' *> refTill "<&\"" <* P.char '\"'
+    singleQuoted = P.char '\'' *> refTill ['<','&','\''] <* P.char '\''
+    doubleQuoted = P.char '"'  *> refTill ['<','&','"']  <* P.char '"'
     refTill end = many (takeWhile1 (not . (`elem` end)) <|> reference)
 
 
@@ -228,16 +228,17 @@ isPubIdChar :: Char -> Bool
 isPubIdChar c | c >= 'a' && c <= 'z'                 = True
               | c >= 'A' && c <= 'Z'                 = True
               | c >= '0' && c <= '9'                 = True
-              | c `elem` " \r\n-\'()+,./:=?;!*#@$_%" = True
+              | c `elem` otherChars                  = True
               | otherwise                            = False
-
+  where
+    otherChars = " \r\n-\'()+,./:=?;!*#@$_%" :: [Char]
 
 ------------------------------------------------------------------------------
 -- | The requirement to not contain "]]>" is for SGML compatibility.  We
 -- deliberately choose to not enforce it.  This makes the parser accept
 -- strictly more documents than a standards-compliant parser.
 charData :: Parser Node
-charData = TextNode <$> takeWhile1 (not . (`elem` "<&"))
+charData = TextNode <$> takeWhile1 (not . (`elem` ['<','&']))
 
 
 ------------------------------------------------------------------------------
@@ -595,6 +596,6 @@ encodingDecl = do
     isEnc      c | c >= 'A' && c <= 'Z' = True
                  | c >= 'a' && c <= 'z' = True
                  | c >= '0' && c <= '9' = True
-                 | c `elem` "._-"       = True
+                 | c `elem` ['.','_','-'] = True
                  | otherwise = False
 


### PR DESCRIPTION
In base-4.8, `elem` has been generalised to `Foldable`, so in
combination with `-XOverloadedStrings`, something like `\c -> elem c
"abc"` can't be type-inferred anymore.
