### PR TITLE
Avoid escaping \n to minimize &#10; pollution

### DIFF
--- a/src/Text/XmlHtml/HTML/Render.hs
+++ b/src/Text/XmlHtml/HTML/Render.hs
@@ -86,7 +86,7 @@ firstNode e (Comment t)     = node e (Comment t)
 firstNode e (Element t a c) = node e (Element t a c)
 firstNode _ (TextNode "")   = mempty
 firstNode e (TextNode t)    = let (c,t') = fromJust $ T.uncons t
-                              in escaped "<>& \t\r\n" e (T.singleton c)
+                              in escaped "<>& \t\r" e (T.singleton c)
                                  `mappend` node e (TextNode t')
 
 

--- a/src/Text/XmlHtml/XML/Render.hs
+++ b/src/Text/XmlHtml/XML/Render.hs
@@ -111,7 +111,7 @@ firstNode e (Comment t)     = node e (Comment t)
 firstNode e (Element t a c) = node e (Element t a c)
 firstNode _ (TextNode "")   = mempty
 firstNode e (TextNode t)    = let (c,t') = fromJust $ T.uncons t
-                              in escaped "<>& \t\r\n" e (T.singleton c)
+                              in escaped "<>& \t\r" e (T.singleton c)
                                  `mappend` node e (TextNode t')
 
 


### PR DESCRIPTION
These changes correct the `&#10;` pollution for xtpl (XML) templates. This accommodates XML parsers that require well-formed XML without extra data following the closure of the root element (e.g., RSS).

This does not address the `&#10;` pollution in HTML files. I'm inclined to think that's coming from another library (perhaps Blaze Builder) as I can't find any source for it in this library.

This change does not affect the successful execution of the test suite:

```
xmlhtml/test [master●] » ./runTestsAndCoverage.sh
byteOrderMark          : [OK]
emptyDocument          : [OK]
publicDocType          : [OK]
systemDocType          : [OK]
emptyDocType           : [OK]
dtdInternalScan        : [OK]
textOnly               : [OK]
textWithRefs           : [OK]
untermRef              : [OK]
textWithCDATA          : [OK]
cdataOnly              : [OK]
commentOnly            : [OK]
emptyElement           : [OK]
emptyElement2          : [OK]
elemWithText           : [OK]
xmlDeclXML             : [OK]
procInst               : [OK]
badDoctype1            : [OK]
badDoctype2            : [OK]
badDoctype3            : [OK]
badDoctype4            : [OK]
badDoctype5            : [OK]
tagNames               : [OK]
emptyDocumentHTML      : [OK]
publicDocTypeHTML      : [OK]
systemDocTypeHTML      : [OK]
emptyDocTypeHTML       : [OK]
textOnlyHTML           : [OK]
textWithRefsHTML       : [OK]
textWithCDataHTML      : [OK]
cdataOnlyHTML          : [OK]
commentOnlyHTML        : [OK]
emptyElementHTML       : [OK]
emptyElement2HTML      : [OK]
elemWithTextHTML       : [OK]
xmlDeclHTML            : [OK]
procInstHTML           : [OK]
badDoctype1HTML        : [OK]
badDoctype2HTML        : [OK]
badDoctype3HTML        : [OK]
badDoctype4HTML        : [OK]
badDoctype5HTML        : [OK]
voidElem               : [OK]
caseInsDoctype1        : [OK]
caseInsDoctype2        : [OK]
voidEmptyElem          : [OK]
rawTextElem            : [OK]
endTagCase             : [OK]
hexEntityCap           : [OK]
laxAttrName            : [OK]
badAttrName            : [OK]
emptyAttr              : [OK]
emptyAttr2             : [OK]
unquotedAttr           : [OK]
laxAttrVal             : [OK]
ampersandInText        : [OK]
omitOptionalEnds       : [OK]
omitEndHEAD            : [OK]
omitEndLI              : [OK]
omitEndDT              : [OK]
omitEndDD              : [OK]
omitEndP               : [OK]
omitEndRT              : [OK]
omitEndRP              : [OK]
omitEndOPTGRP          : [OK]
omitEndOPTION          : [OK]
omitEndCOLGRP          : [OK]
omitEndTHEAD           : [OK]
omitEndTBODY           : [OK]
omitEndTFOOT           : [OK]
omitEndTR              : [OK]
omitEndTD              : [OK]
omitEndTH              : [OK]
testNewRefs            : [OK]
errorImplicitClose     : [OK]
weirdScriptThing       : [OK]
renderByteOrderMark    : [OK]
renderByteOrderMarkLE  : [OK]
singleQuoteInSysID     : [OK]
doubleQuoteInSysID     : [OK]
bothQuotesInSysID      : [OK]
doubleQuoteInPubID     : [OK]
doubleDashInComment    : [OK]
trailingDashInComment  : [OK]
renderEmptyText        : [OK]
singleQuoteInAttr      : [OK]
doubleQuoteInAttr      : [OK]
bothQuotesInAttr       : [OK]
hRenderByteOrderMark   : [OK]
hSingleQuoteInSysID    : [OK]
hDoubleQuoteInSysID    : [OK]
hBothQuotesInSysID     : [OK]
hDoubleQuoteInPubID    : [OK]
hDoubleDashInComment   : [OK]
hTrailingDashInComment : [OK]
hRenderEmptyText       : [OK]
hSingleQuoteInAttr     : [OK]
hDoubleQuoteInAttr     : [OK]
hBothQuotesInAttr      : [OK]
renderHTMLVoid         : [OK]
renderHTMLVoid2        : [OK]
renderHTMLRaw          : [OK]
renderHTMLRawMult      : [OK]
renderHTMLRaw2         : [OK]
renderHTMLRaw3         : [OK]
renderHTMLRaw4         : [OK]
renderHTMLAmpAttr1     : [OK]
renderHTMLAmpAttr2     : [OK]
renderHTMLAmpAttr3     : [OK]
renderHTMLQVoid        : [OK]
renderHTMLQVoid2       : [OK]
renderHTMLQRaw         : [OK]
renderHTMLQRawMult     : [OK]
renderHTMLQRaw2        : [OK]
renderHTMLQRaw3        : [OK]
renderHTMLQRaw4        : [OK]
compareExternalIDs     : [OK]
compareInternalSubs    : [OK]
compareDoctypes        : [OK]
compareNodes           : [OK]
compareDocuments       : [OK]
compareEncodings       : [OK]
exerciseShows          : [OK]
docNodeAccessors       : [OK]
isTextNodeYes          : [OK]
isTextNodeNo           : [OK]
isTextNodeNo2          : [OK]
isCommentYes           : [OK]
isCommentNo            : [OK]
isCommentNo2           : [OK]
isElementYes           : [OK]
isElementNo            : [OK]
isElementNo2           : [OK]
tagNameElement         : [OK]
tagNameText            : [OK]
tagNameComment         : [OK]
getAttributePresent    : [OK]
getAttributeMissing    : [OK]
getAttributeWrongType  : [OK]
hasAttributePresent    : [OK]
hasAttributeMissing    : [OK]
hasAttributeWrongType  : [OK]
setAttributeNew        : [OK]
setAttributeReplace    : [OK]
setAttributeWrongType  : [OK]
nestedNodeText         : [OK]
childNodesElem         : [OK]
childNodesOther        : [OK]
childElemsTest         : [OK]
childElemsTagTest      : [OK]
childElemTagExists     : [OK]
childElemTagNotExists  : [OK]
childElemTagOther      : [OK]
descNodesElem          : [OK]
descNodesOther         : [OK]
descElemsTest          : [OK]
descElemsTagTest       : [OK]
descElemTagExists      : [OK]
descElemTagDFS         : [OK]
descElemTagNotExists   : [OK]
descElemTagOther       : [OK]
fromNodeAndCurrent     : [OK]
fromNodesAndSiblings   : [OK]
leftSiblings           : [OK]
emptyFromNodes         : [OK]
cursorNEQ              : [OK]
cursorNavigation       : [OK]
cursorSearch           : [OK]
cursorMutation         : [OK]
cursorInsertion        : [OK]
cursorDeletion         : [OK]
blazeTestString        : [OK]
blazeTestText          : [OK]
blazeTestBS            : [OK]
blazeTestPre           : [OK]
blazeTestExternal      : [OK]
blazeTestCustom        : [OK]
blazeTestMulti         : [OK]
blazeTestEmpty         : [OK]
xmlhtml/ibm-not-wf     : [OK]
xmlhtml/ibm-invalid    : [OK]
xmlhtml/ibm-valid      : [OK]
xmlhtml/oasis          : [OK]
xmlhtml/r-ibm-not-wf   : [OK]
xmlhtml/r-ibm-invalid  : [OK]
xmlhtml/r-ibm-valid    : [OK]
xmlhtml/r-oasis        : [OK]
xmlhtml/h-ibm-not-wf   : [OK]
xmlhtml/h-ibm-invalid  : [OK]
xmlhtml/h-ibm-valid    : [OK]
xmlhtml/h-oasis        : [OK]
xmlhtml/hr-ibm-not-wf  : [OK]
xmlhtml/hr-ibm-invalid : [OK]
xmlhtml/hr-ibm-valid   : [OK]
xmlhtml/hr-oasis       : [OK]

         Test Cases    Total
 Passed  195           195
 Failed  0             0
 Total   195           195
```