### PR TITLE
Relax HUnit bounds in xmlhtml-testsuite

### DIFF
--- a/test/xmlhtml-testsuite.cabal
+++ b/test/xmlhtml-testsuite.cabal
@@ -8,7 +8,7 @@ Executable testsuite
   main-is:         TestSuite.hs
 
   build-depends:
-    HUnit                      == 1.2.*,
+    HUnit                      >= 1.2      && <1.4,
     directory                  >= 1.0      && <1.3,
     QuickCheck                 >= 2.3.0.2,
     base,


### PR DESCRIPTION
I have run the tests manually with this change pulling in `HUnit-1.3.1.1`