### PR TITLE
xmlhtml.cabal: test just built library in testsuite

### DIFF
--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -841,26 +841,22 @@ Library
   ghc-options:         -Wall -fwarn-tabs -fno-warn-orphans
 
 Test-suite testsuite
-  hs-source-dirs: src test/src
+  hs-source-dirs: test/src
   type: exitcode-stdio-1.0
   main-is: TestSuite.hs
 
   build-depends:
     HUnit                      >= 1.2      && <1.4,
-    QuickCheck                 >= 2.3.0.2,
     base,
     blaze-builder,
     blaze-html,
     blaze-markup,
     bytestring,
-    containers,
     directory                  >= 1.0      && <1.3,
-    parsec,
     test-framework             >= 0.8.0.3  && <0.9,
     test-framework-hunit       >= 0.3      && <0.4,
-    test-framework-quickcheck2 >= 0.3      && <0.4,
     text,
-    unordered-containers
+    xmlhtml
 
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -threaded
                -fno-warn-unused-do-bind


### PR DESCRIPTION
Change avoids rebuilding non-test modules twice
and removes unused depends.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>