### PR TITLE
Relax upper bound on HUnit to allow 1.4

### DIFF
--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -1,5 +1,5 @@
 Name:                xmlhtml
-Version:             0.2.3.5
+Version:             0.2.3.6
 Synopsis:            XML parser and renderer with HTML 5 quirks mode
 Description:         Contains renderers and parsers for both XML and HTML 5
                      document fragments, which share data structures so that
@@ -846,7 +846,7 @@ Test-suite testsuite
   main-is: TestSuite.hs
 
   build-depends:
-    HUnit                      >= 1.2      && <1.4,
+    HUnit                      >= 1.2      && <1.5,
     base,
     blaze-builder,
     blaze-html,


### PR DESCRIPTION
I have checked that the tests succeed when using HUnit-1.4.0.0

(Forcing HUnit-1.4.0.0 currently requires an updated test-framework-hunit too - see https://github.com/haskell/test-framework/pull/24)