### PR TITLE
Allow HUnit 1.5

### DIFF
--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -846,7 +846,7 @@ Test-suite testsuite
   main-is: TestSuite.hs
 
   build-depends:
-    HUnit                      >= 1.2      && <1.5,
+    HUnit                      >= 1.2      && <1.6,
     base,
     blaze-builder,
     blaze-html,


### PR DESCRIPTION
It's becoming hard to keep up with HUnit!  I've checked that the tests succeed when using HUnit-1.5.0.0.

I' have not changed the version number, since you just made a revision on hackage last time.

Again, forcing HUnit-1.5.0.0 currently requires an updated test-framework-hunit too - see https://github.com/haskell/test-framework/pull/25