### PR TITLE
Bump version bound for Directory in tests

### DIFF
--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -852,7 +852,7 @@ Test-suite testsuite
     blaze-html,
     blaze-markup,
     bytestring,
-    directory                  >= 1.0      && <1.3,
+    directory                  >= 1.0      && <1.4,
     test-framework             >= 0.8.0.3  && <0.9,
     test-framework-hunit       >= 0.3      && <0.4,
     text,


### PR DESCRIPTION
I have checked that the tests build and pass with directory-1.3.0.0 - in fact, as far as I can see, it is only being used for `doesFileExist` in the OASIS test, so the bound is pretty unlikely ever to matter.

1.3.0.0 is the version bundled with ghc-8.0.2, and this is an issue for this package in stackage: https://github.com/fpco/stackage/issues/2203

Previously you preferred to make a hackage revision in the short term for version bounds, so I've not changed the version number here.