### PR TITLE
Changes to work with blaze-markup-0.8.0

### DIFF
--- a/src/Text/Blaze/Renderer/XmlHtml.hs
+++ b/src/Text/Blaze/Renderer/XmlHtml.hs
@@ -48,6 +48,14 @@ fromChoiceString EmptyChoiceString = id
 {-# INLINE fromChoiceString #-}
 
 
+-- Blaze-markup-0.8.0 changed some alternatives of MarkupM, adding a parameter
+-- which needs to be included in the pattern matches below.
+#if MIN_VERSION_blaze_markup(0,8,0)
+#define MARKUP_080 _
+#else
+#define MARKUP_080
+#endif
+
 -- | Render some 'Html' to an appending list of nodes
 --
 renderNodes :: Html -> [Node] -> [Node]
@@ -58,22 +66,22 @@ renderNodes = go []
         (Element (getText tag) attrs (go [] content []) :)
     go attrs (CustomParent tag content) =
         (Element (fromChoiceStringText tag) attrs (go [] content []) :)
-    go attrs (Leaf tag _ _) =
+    go attrs (Leaf tag _ _ MARKUP_080) =
         (Element (getText tag) attrs [] :)
-    go attrs (CustomLeaf tag _) =
+    go attrs (CustomLeaf tag _ MARKUP_080) =
         (Element (fromChoiceStringText tag) attrs [] :)
     go attrs (AddAttribute key _ value content) =
         go ((getText key, fromChoiceStringText value) : attrs) content
     go attrs (AddCustomAttribute key value content) =
         go ((fromChoiceStringText key, fromChoiceStringText value) : attrs)
            content
-    go _ (Content content) = fromChoiceString content
+    go _ (Content content MARKUP_080) = fromChoiceString content
 #if MIN_VERSION_blaze_markup(0,6,3)
-    go _ (TBI.Comment comment) =
+    go _ (TBI.Comment comment MARKUP_080) =
         (X.Comment (fromChoiceStringText comment) :)
 #endif
     go attrs (Append h1 h2) = go attrs h1 . go attrs h2
-    go _ Empty = id
+    go _ (Empty MARKUP_080) = id
     {-# NOINLINE go #-}
 {-# INLINE renderNodes #-}
 

--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -1,5 +1,5 @@
 Name:                xmlhtml
-Version:             0.2.3.6
+Version:             0.3.0
 Synopsis:            XML parser and renderer with HTML 5 quirks mode
 Description:         Contains renderers and parsers for both XML and HTML 5
                      document fragments, which share data structures so that
@@ -821,8 +821,8 @@ Library
 
   Build-depends:       base                 >= 4     && < 5,
                        blaze-builder        >= 0.2   && < 0.5,
-                       blaze-html           >= 0.5   && < 0.9,
-                       blaze-markup         >= 0.5   && < 0.8,
+                       blaze-html           >= 0.5   && < 0.10,
+                       blaze-markup         >= 0.5   && < 0.9,
                        bytestring           >= 0.9   && < 0.11,
                        containers           >= 0.3   && < 0.6,
                        parsec               >= 3.1.2 && < 3.2,


### PR DESCRIPTION
I've tried to make the conditional compilation as clean as possible, under the circumstances!  The tests run successfully with both blaze-markup-0.8.0 and blaze-markup-0.7.1.1 (with corresponding versions of blaze-html).

I put in a major version bump because the type of `renderHtml` changes as a result of MarkupM changing, but I admit the PVP confuses me in situations like this.