### PR TITLE
Protect against exceptions when parsing invalid character references

### DIFF
--- a/src/Text/XmlHtml/Common.hs
+++ b/src/Text/XmlHtml/Common.hs
@@ -8,7 +8,7 @@ import           Data.ByteString (ByteString)
 import           Blaze.ByteString.Builder
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Builder as B
-import           Data.Char (isAscii, isLatin1)
+import           Data.Char (chr, isAscii, isLatin1)
 import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet as S
 import qualified Data.Map as Map
@@ -20,6 +20,8 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Encoding.Error as TE
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
+
+import           Text.Parsec.Text (Parser)
 
 import           Text.XmlHtml.HTML.Meta (reversePredefinedRefs,
                                          explicitAttributes)
@@ -306,3 +308,11 @@ bmap f   = B.byteString
                . TL.toStrict
                . TL.decodeUtf8
                . B.toLazyByteString
+
+------------------------------------------------------------------------------
+-- Lookup a character code in some monad (usually a parser)
+safeChr :: Int -> Parser Char
+safeChr c =
+    if c > 1114111
+      then fail ("Invalid character code: " ++ show c)
+      else return (chr c)

--- a/src/Text/XmlHtml/HTML/Parse.hs
+++ b/src/Text/XmlHtml/HTML/Parse.hs
@@ -344,8 +344,7 @@ finishCharRef = P.char '#' *> (hexCharRef <|> decCharRef)
     decCharRef = do
         ds <- some digit
         _ <- P.char ';'
-        let c = chr $ foldl' (\a b -> 10 * a + b) 0 ds
-        return c
+        safeChr $ foldl' (\a b -> 10 * a + b) 0 ds
       where
         digit = do
             d <- P.satisfy (\c -> c >= '0' && c <= '9')
@@ -354,8 +353,7 @@ finishCharRef = P.char '#' *> (hexCharRef <|> decCharRef)
         _ <- P.char 'x' <|> P.char 'X'
         ds <- some digit
         _ <- P.char ';'
-        let c = chr $ foldl' (\a b -> 16 * a + b) 0 ds
-        return c
+        safeChr $ foldl' (\a b -> 16 * a + b) 0 ds
       where
         digit = num <|> upper <|> lower
         num = do

--- a/src/Text/XmlHtml/XML/Parse.hs
+++ b/src/Text/XmlHtml/XML/Parse.hs
@@ -506,7 +506,7 @@ charRef = hexCharRef <|> decCharRef
         _ <- text "&#"
         ds <- some digit
         _ <- P.char ';'
-        let c = chr $ foldl' (\a b -> 10 * a + b) 0 ds
+        c <- safeChr $ foldl' (\a b -> 10 * a + b) 0 ds
         when (not (isValidChar c)) $ fail $
             "Reference is not a valid character"
         return $ T.singleton c
@@ -518,7 +518,7 @@ charRef = hexCharRef <|> decCharRef
         _ <- text "&#x"
         ds <- some digit
         _ <- P.char ';'
-        let c = chr $ foldl' (\a b -> 16 * a + b) 0 ds
+        c <- safeChr $ foldl' (\a b -> 16 * a + b) 0 ds
         when (not (isValidChar c)) $ fail $
             "Reference is not a valid character"
         return $ T.singleton c

--- a/test/src/Text/XmlHtml/TestCommon.hs
+++ b/test/src/Text/XmlHtml/TestCommon.hs
@@ -41,3 +41,7 @@ isBottom a = unsafePerformIO $
 isLeft :: Either a b -> Bool
 isLeft = either (const True) (const False)
 
+------------------------------------------------------------------------------
+isRight :: Either a b -> Bool
+isRight = not . isLeft
+

--- a/test/src/Text/XmlHtml/Tests.hs
+++ b/test/src/Text/XmlHtml/Tests.hs
@@ -251,6 +251,7 @@ htmlXMLParsingTests = do
     testIt "badDoctype3HTML        " badDoctype3HTML
     testIt "badDoctype4HTML        " badDoctype4HTML
     testIt "badDoctype5HTML        " badDoctype5HTML
+    testIt "outOfBoundsChr         " outOfBoundsChr
 
 emptyDocumentHTML :: Bool
 emptyDocumentHTML = parseHTML "" ""
@@ -324,6 +325,8 @@ badDoctype5HTML :: Bool
 badDoctype5HTML    = isLeft $ parseHTML "" ("<!DOCTYPE html SYSTEM \"foo\" "
                                        `B.append` "PUBLIC \"bar\" \"baz\">")
 
+outOfBoundsChr :: Bool
+outOfBoundsChr = isRight $ parseHTML "" "<p>&#100000000000;</p>"
 
 ------------------------------------------------------------------------------
 -- HTML Quirks Parsing Tests -------------------------------------------------

--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -816,7 +816,7 @@ common universal
   default-language: Haskell2010
 
   build-depends:
-    , base >= 4.5 && < 4.18
+    , base >= 4.12 && < 4.18
 
 Library
   import:              universal


### PR DESCRIPTION
## tl;dr
 - Add `safeChr :: Int -> Parsec.Parser Char`, which asserts that the `Int` can be turned into a `Char`.
 - Use `safeChr` in XML reference parser (the parser handling escape sequences like `"&#65"`). Failure causes the whole document parse to fail.
 - Use `safeChr` in HTML reference parser. Failure causes the parser to ignore invalid references (passing them through to the Node tree unchanged).

## Details

HTML and XML parsers use `Data.Char.chr` to map from an escape sequence (`"&#65;"`) to a unicode character. This is unsafe because `chr` throws an exception when called on integers greater than 1114111, and an input document may contain such a large escape sequence, by user error or a malicious user.

This PR adds a function `safeChr`, which checks the validity of the int argument before calling `Data.Char.chr`, failing in `Text.Parsec.Text.Parser` monad when the argument is invalid. And it replaces `Data.Char.chr` with `safeChr` everywhere `Data.Char.chr` was being used in a parser.

In the HTML parser, failing during numerical entity parsing falls back to the original text (e.g. `"&#9999999"` in the input document will be preserved as it, not interpreted as a single html entity as `"&#65"` is interpreted to 'A').

But In the XML parser, failing to parse the entity causes the whole document parser to fail. 

The difference between XML and HTML parser behavior is somewhat arbitrary. I can hand-wave a case that we want the HTML parser to be more forgiving and the XML parser to be more strict. But I'm very open to suggestions here.