### PR TITLE
Add RenderingOptions for setting the attribute value surround char

### DIFF
--- a/src/Text/XmlHtml.hs
+++ b/src/Text/XmlHtml.hs
@@ -32,6 +32,8 @@ module Text.XmlHtml (
     ExternalID(..),
     InternalSubset(..),
     Encoding(..),
+    RenderOptions(..),
+    AttributeSurround(..),
 
     -- * Manipulating documents
     isTextNode,
@@ -57,6 +59,7 @@ module Text.XmlHtml (
 
     -- * Rendering
     render,
+    renderWithOptions,
     XMLR.renderXmlFragment,
     HTML.renderHtmlFragment,
     renderDocType
@@ -101,9 +104,12 @@ parseHTML = parse HTML.docFragment
 
 ------------------------------------------------------------------------------
 -- | Renders a 'Document'.
+renderWithOptions :: RenderOptions -> Document -> Builder
+renderWithOptions opts (XmlDocument  e dt ns) = XMLR.renderWithOptions opts e dt ns
+renderWithOptions opts (HtmlDocument e dt ns) = HTML.renderWithOptions opts e dt ns
+
 render :: Document -> Builder
-render (XmlDocument  e dt ns) = XMLR.render  e dt ns
-render (HtmlDocument e dt ns) = HTML.render e dt ns
+render doc = renderWithOptions defaultRenderOptions doc
 
 
 renderDocType :: Encoding -> Maybe DocType -> Builder

--- a/src/Text/XmlHtml/Common.hs
+++ b/src/Text/XmlHtml/Common.hs
@@ -51,6 +51,19 @@ data Node = TextNode !Text
 
 
 ------------------------------------------------------------------------------
+-- | Rendering options. Attritube values may be surrounded by single quotes
+-- (default), or by double quotes
+data RenderOptions = RenderOptions {
+    attributeSurround :: AttributeSurround
+    }
+
+data AttributeSurround = SurroundDoubleQuote | SurroundSingleQuote
+    deriving (Eq, Ord, Show)
+
+defaultRenderOptions :: RenderOptions
+defaultRenderOptions = RenderOptions SurroundSingleQuote
+
+------------------------------------------------------------------------------
 -- | Determines whether the node is text or not.
 isTextNode :: Node -> Bool
 isTextNode (TextNode _) = True

--- a/src/Text/XmlHtml/HTML/Render.hs
+++ b/src/Text/XmlHtml/HTML/Render.hs
@@ -25,24 +25,26 @@ import           Data.Monoid
 
 ------------------------------------------------------------------------------
 -- | And, the rendering code.
-render :: Encoding -> Maybe DocType -> [Node] -> Builder
-render e dt ns = byteOrder
+renderWithOptions :: RenderOptions -> Encoding -> Maybe DocType -> [Node] -> Builder
+renderWithOptions opts e dt ns = byteOrder
        `mappend` docTypeDecl e dt
        `mappend` nodes
     where byteOrder | isUTF16 e = fromText e "\xFEFF" -- byte order mark
                     | otherwise = mempty
           nodes | null ns   = mempty
-                | otherwise = firstNode e (head ns)
-                    `mappend` (mconcat $ map (node e) (tail ns))
+                | otherwise = firstNode opts e (head ns)
+                    `mappend` (mconcat $ map (node opts e) (tail ns))
 
+render :: Encoding -> Maybe DocType -> [Node] -> Builder
+render = renderWithOptions defaultRenderOptions
 
 ------------------------------------------------------------------------------
 -- | Function for rendering HTML nodes without the overhead of creating a
 -- Document structure.
-renderHtmlFragment :: Encoding -> [Node] -> Builder
-renderHtmlFragment _ []     = mempty
-renderHtmlFragment e (n:ns) =
-    firstNode e n `mappend` (mconcat $ map (node e) ns)
+renderHtmlFragment :: RenderOptions -> Encoding -> [Node] -> Builder
+renderHtmlFragment _ _ []     = mempty
+renderHtmlFragment opts e (n:ns) =
+    firstNode opts e n `mappend` (mconcat $ map (node opts e) ns)
 
 
 ------------------------------------------------------------------------------
@@ -66,39 +68,39 @@ escaped bad e t  =
 
 
 ------------------------------------------------------------------------------
-node :: Encoding -> Node -> Builder
-node e (TextNode t)                        = escaped "<>&" e t
-node e (Comment t) | "--" `T.isInfixOf`  t = error "Invalid comment"
-                   | "-"  `T.isSuffixOf` t = error "Invalid comment"
-                   | otherwise             = fromText e "<!--"
-                                             `mappend` fromText e t
-                                             `mappend` fromText e "-->"
-node e (Element t a c)                     =
+node :: RenderOptions -> Encoding -> Node -> Builder
+node _ e (TextNode t)                        = escaped "<>&" e t
+node _ e (Comment t) | "--" `T.isInfixOf`  t = error "Invalid comment"
+                     | "-"  `T.isSuffixOf` t = error "Invalid comment"
+                     | otherwise             = fromText e "<!--"
+                                               `mappend` fromText e t
+                                               `mappend` fromText e "-->"
+node opts e (Element t a c)                     =
     let tbase = T.toLower $ snd $ T.breakOnEnd ":" t
-    in  element e t tbase a c
+    in  element opts e t tbase a c
 
 
 ------------------------------------------------------------------------------
 -- | Process the first node differently to encode leading whitespace.  This
 -- lets us be sure that @parseHTML@ is a left inverse to @render@.
-firstNode :: Encoding -> Node -> Builder
-firstNode e (Comment t)     = node e (Comment t)
-firstNode e (Element t a c) = node e (Element t a c)
-firstNode _ (TextNode "")   = mempty
-firstNode e (TextNode t)    = let (c,t') = fromJust $ T.uncons t
-                              in escaped "<>& \t\r" e (T.singleton c)
-                                 `mappend` node e (TextNode t')
+firstNode :: RenderOptions -> Encoding -> Node -> Builder
+firstNode opts e (Comment t)     = node opts e (Comment t)
+firstNode opts e (Element t a c) = node opts e (Element t a c)
+firstNode _    _ (TextNode "")   = mempty
+firstNode opts e (TextNode t)    = let (c,t') = fromJust $ T.uncons t
+                                   in escaped "<>& \t\r" e (T.singleton c)
+                                      `mappend` node opts e (TextNode t')
 
 
 ------------------------------------------------------------------------------
 -- XXX: Should do something to avoid concatting large CDATA sections before
 -- writing them to the output.
-element :: Encoding -> Text -> Text -> [(Text, Text)] -> [Node] -> Builder
-element e t tb a c
+element :: RenderOptions -> Encoding -> Text -> Text -> [(Text, Text)] -> [Node] -> Builder
+element opts e t tb a c
     | tb `S.member` voidTags && null c         =
         fromText e "<"
         `mappend` fromText e t
-        `mappend` (mconcat $ map (attribute e) a)
+        `mappend` (mconcat $ map (attribute opts e) a)
         `mappend` fromText e " />"
     | tb `S.member` voidTags                   =
         error $ T.unpack t ++ " must be empty"
@@ -108,7 +110,7 @@ element e t tb a c
       not ("</" `T.append` t `T.isInfixOf` s) =
         fromText e "<"
         `mappend` fromText e t
-        `mappend` (mconcat $ map (attribute e) a)
+        `mappend` (mconcat $ map (attribute opts e) a)
         `mappend` fromText e ">"
         `mappend` fromText e s
         `mappend` fromText e "</"
@@ -122,30 +124,33 @@ element e t tb a c
     | otherwise =
         fromText e "<"
         `mappend` fromText e t
-        `mappend` (mconcat $ map (attribute e) a)
+        `mappend` (mconcat $ map (attribute opts e) a)
         `mappend` fromText e ">"
-        `mappend` (mconcat $ map (node e) c)
+        `mappend` (mconcat $ map (node opts e) c)
         `mappend` fromText e "</"
         `mappend` fromText e t
         `mappend` fromText e ">"
 
 
 ------------------------------------------------------------------------------
-attribute :: Encoding -> (Text, Text) -> Builder
-attribute e (n,v)
+attribute :: RenderOptions -> Encoding -> (Text, Text) -> Builder
+attribute opts e (n,v)
     | v == ""                    =
         fromText e " "
         `mappend` fromText e n
-    | not ("\'" `T.isInfixOf` v) =
+    | not (preferredSurround `T.isInfixOf` v) =
         fromText e " "
         `mappend` fromText e n
-        `mappend` fromText e "=\'"
+        `mappend` fromText e ('=' `T.cons` preferredSurround)
         `mappend` escaped "&" e v
-        `mappend` fromText e "\'"
+        `mappend` fromText e preferredSurround
     | otherwise                  =
         fromText e " "
         `mappend` fromText e n
-        `mappend` fromText e "=\""
+        `mappend` fromText e ('=' `T.cons` otherSurround)
         `mappend` escaped "&\"" e v
-        `mappend` fromText e "\""
+        `mappend` fromText e otherSurround
+    where (preferredSurround, otherSurround) = case attributeSurround opts of
+            SurroundDoubleQuote -> ("\"", "\'")
+            SurroundSingleQuote -> ("\'", "\"")
 

--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -1,5 +1,5 @@
 Name:                xmlhtml
-Version:             0.2.4
+Version:             0.2.5
 Synopsis:            XML parser and renderer with HTML 5 quirks mode
 Description:         Contains renderers and parsers for both XML and HTML 5
                      document fragments, which share data structures so that

--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -852,6 +852,7 @@ Test-suite testsuite
     blaze-html,
     blaze-markup,
     bytestring,
+    bytestring-builder,
     directory                  >= 1.0      && <1.4,
     test-framework             >= 0.8.0.3  && <0.9,
     test-framework-hunit       >= 0.3      && <0.4,


### PR DESCRIPTION
We sometimes care about the use of single vs. double quotes in the rendering of a `Document`. This PR adds a `renderWithOptions` rendering variant and `RenderOptions` type for this purpose.

If other rendering options come up in the future, we can add them as fields to the `RenderOptions` type.