### PR TITLE
Update test cases and fix travis build

### DIFF
--- a/src/Text/XmlHtml.hs
+++ b/src/Text/XmlHtml.hs
@@ -33,8 +33,8 @@ module Text.XmlHtml (
     InternalSubset(..),
     Encoding(..),
     RenderOptions(..),
-    AttributeSurround(..),
-    AttributeInternalQuotes(..),
+    AttrSurround(..),
+    AttrResolveInternalQuotes(..),
 
     -- * Manipulating documents
     isTextNode,

--- a/src/Text/XmlHtml.hs
+++ b/src/Text/XmlHtml.hs
@@ -34,6 +34,7 @@ module Text.XmlHtml (
     Encoding(..),
     RenderOptions(..),
     AttributeSurround(..),
+    AttributeInternalQuotes(..),
 
     -- * Manipulating documents
     isTextNode,

--- a/src/Text/XmlHtml/Common.hs
+++ b/src/Text/XmlHtml/Common.hs
@@ -57,15 +57,20 @@ data Node = TextNode !Text
 -- (default), or by double quotes
 data RenderOptions = RenderOptions {
       attributeSurround       :: AttributeSurround
+    , attributeInternal       :: AttributeInternalQuotes
     , explicitEmptyAttributes :: M.HashMap Text (S.HashSet Text)
-    }
+    } deriving (Eq, Show)
 
 data AttributeSurround = SurroundDoubleQuote | SurroundSingleQuote
+    deriving (Eq, Ord, Show)
+
+data AttributeInternalQuotes = AttributeEscapeQuotes | AttributeChangeSurround
     deriving (Eq, Ord, Show)
 
 defaultRenderOptions :: RenderOptions
 defaultRenderOptions = RenderOptions
     { attributeSurround       = SurroundSingleQuote
+    , attributeInternal       = AttributeChangeSurround
     , explicitEmptyAttributes = explicitAttributes
     }
 

--- a/src/Text/XmlHtml/Common.hs
+++ b/src/Text/XmlHtml/Common.hs
@@ -53,25 +53,34 @@ data Node = TextNode !Text
 
 
 ------------------------------------------------------------------------------
--- | Rendering options. Attritube values may be surrounded by single quotes
--- (default), or by double quotes
+-- | Rendering options
 data RenderOptions = RenderOptions {
-      attributeSurround       :: AttributeSurround
-    , attributeInternal       :: AttributeInternalQuotes
-    , explicitEmptyAttributes :: M.HashMap Text (S.HashSet Text)
+      roAttributeSurround :: AttrSurround
+      -- ^ Single or double-quotes used around attribute values
+
+    , roAttributeResolveInternal :: AttrResolveInternalQuotes
+      -- ^ Quotes inside attribute values that conflict with the surround
+      -- are escaped, or the outer quotes are changed to avoid conflicting
+      -- with the internal ones
+
+    , roExplicitEmptyAttrs :: Maybe (M.HashMap Text (S.HashSet Text))
+      -- ^ Attributes in the whitelist with empty values are
+      -- rendered as <div example="">
+      -- 'Nothing' applies this rule to all attributes with empty values
+
     } deriving (Eq, Show)
 
-data AttributeSurround = SurroundDoubleQuote | SurroundSingleQuote
+data AttrSurround = SurroundDoubleQuote | SurroundSingleQuote
     deriving (Eq, Ord, Show)
 
-data AttributeInternalQuotes = AttributeEscapeQuotes | AttributeChangeSurround
+data AttrResolveInternalQuotes = AttrResolveByEscape | AttrResolveAvoidEscape
     deriving (Eq, Ord, Show)
 
 defaultRenderOptions :: RenderOptions
 defaultRenderOptions = RenderOptions
-    { attributeSurround       = SurroundSingleQuote
-    , attributeInternal       = AttributeChangeSurround
-    , explicitEmptyAttributes = explicitAttributes
+    { roAttributeSurround        = SurroundSingleQuote
+    , roAttributeResolveInternal = AttrResolveAvoidEscape
+    , roExplicitEmptyAttrs       = Just explicitAttributes
     }
 
 ------------------------------------------------------------------------------

--- a/src/Text/XmlHtml/Common.hs
+++ b/src/Text/XmlHtml/Common.hs
@@ -4,7 +4,10 @@
 
 module Text.XmlHtml.Common where
 
+import           Data.ByteString (ByteString)
 import           Blaze.ByteString.Builder
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Builder as B
 import           Data.Char (isAscii, isLatin1)
 import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet as S
@@ -14,9 +17,9 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Encoding.Error as TE
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TL
 
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BS
 import           Text.XmlHtml.HTML.Meta (reversePredefinedRefs,
                                          explicitAttributes)
 
@@ -294,3 +297,11 @@ isUTF16 e = e == UTF16BE || e == UTF16LE
 fromText :: Encoding -> Text -> Builder
 fromText e t = fromByteString (encoder e t)
 
+
+bmap :: (Text -> Text) -> B.Builder -> B.Builder
+bmap f   = B.byteString
+               . T.encodeUtf8
+               . f
+               . TL.toStrict
+               . TL.decodeUtf8
+               . B.toLazyByteString

--- a/src/Text/XmlHtml/HTML/Render.hs
+++ b/src/Text/XmlHtml/HTML/Render.hs
@@ -171,6 +171,10 @@ attribute opts e tb (n,v)
                . TL.toStrict
                . TL.decodeUtf8
                . B.toLazyByteString
-    explicit = case M.lookup tb (explicitEmptyAttributes opts) of
-        Nothing -> False
-        Just ns -> nbase `S.member` ns
+    explicit = case explicitEmptyAttributes opts of
+        Nothing  -> True
+        -- ^ Nothing 'explicitEmptyAttributes' means: attach '=""' to all
+        -- empty attributes
+        Just els -> case M.lookup tb els of
+            Nothing -> False
+            Just ns -> nbase `S.member` ns

--- a/src/Text/XmlHtml/HTML/Render.hs
+++ b/src/Text/XmlHtml/HTML/Render.hs
@@ -171,6 +171,6 @@ attribute opts e tb (n,v)
                . TL.toStrict
                . TL.decodeUtf8
                . B.toLazyByteString
-    explicit = case M.lookup tb explicitAttributes of
+    explicit = case M.lookup tb (explicitEmptyAttributes opts) of
         Nothing -> False
         Just ns -> nbase `S.member` ns

--- a/src/Text/XmlHtml/HTML/Render.hs
+++ b/src/Text/XmlHtml/HTML/Render.hs
@@ -7,10 +7,12 @@ module Text.XmlHtml.HTML.Render where
 import           Blaze.ByteString.Builder
 import           Control.Applicative
 import qualified Data.ByteString.Builder as B
+import qualified Data.HashMap.Strict as M
+import qualified Data.HashSet as S
 import           Data.Maybe
 import qualified Data.Text.Encoding as T
-import qualified Data.Text.Lazy.Encoding as TL
 import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TL
 import qualified Text.Parsec as P
 import           Text.XmlHtml.Common
 import           Text.XmlHtml.TextParser
@@ -21,8 +23,6 @@ import           Text.XmlHtml.XML.Render (docTypeDecl, entity)
 import           Data.Text (Text)
 import qualified Data.Text as T
 
-import qualified Data.HashSet as S
-import qualified Data.HashMap.Strict as M
 
 #if !MIN_VERSION_base(4,8,0)
 import           Data.Monoid

--- a/src/Text/XmlHtml/XML/Render.hs
+++ b/src/Text/XmlHtml/XML/Render.hs
@@ -172,6 +172,6 @@ attribute opts e (n,v)
       `mappend` fromText e (T.cons '=' otherSurround)
       `mappend` escaped "<&\"" e v
       `mappend` fromText e otherSurround
-    where (preferredSurround, otherSurround) = case attributeSurround opts of
+    where (preferredSurround, otherSurround) = case roAttributeSurround opts of
             SurroundDoubleQuote -> ("\"", "\'")
             SurroundSingleQuote -> ("\'", "\"")

--- a/src/Text/XmlHtml/XML/Render.hs
+++ b/src/Text/XmlHtml/XML/Render.hs
@@ -4,13 +4,9 @@
 
 module Text.XmlHtml.XML.Render where
 
-import qualified Data.ByteString.Builder as B
 import           Blaze.ByteString.Builder
 import           Data.Char
 import           Data.Maybe
-import qualified Data.Text.Encoding as T
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Lazy.Encoding as TL
 import           Text.XmlHtml.Common
 
 import           Data.Text (Text)
@@ -165,27 +161,20 @@ element opts e t a c = fromText e "<"
 attribute :: RenderOptions -> Encoding -> (Text, Text) -> Builder
 attribute opts e (n,v)
     | roAttributeResolveInternal opts == AttrResolveAvoidEscape
-      && preferredSurround `T.isInfixOf` v
-      && not (otherSurround `T.isInfixOf` v) =
+      && surround `T.isInfixOf` v
+      && not (alternative `T.isInfixOf` v) =
       fromText e " "
       `mappend` fromText e n
-      `mappend` fromText e (T.cons '=' otherSurround)
+      `mappend` fromText e (T.cons '=' alternative)
       `mappend` escaped "<&" e v
-      `mappend` fromText e otherSurround
+      `mappend` fromText e alternative
     | otherwise =
       fromText e " "
       `mappend` fromText e n
-      `mappend` fromText e (T.cons '=' preferredSurround)
-      `mappend` bmap (T.replace preferredSurround ent) (escaped "<&" e v)
-      `mappend` fromText e preferredSurround
+      `mappend` fromText e (T.cons '=' surround)
+      `mappend` bmap (T.replace surround ent) (escaped "<&" e v)
+      `mappend` fromText e surround
   where
-    (preferredSurround, otherSurround, ent) = case roAttributeSurround opts of
-        SurroundSingleQuote -> ("\'", "\"", "&apos;")
-        SurroundDoubleQuote -> ("\"", "\'", "&quot;")
-    bmap :: (T.Text -> T.Text) -> B.Builder -> B.Builder
-    bmap f   = B.byteString
-               . T.encodeUtf8
-               . f
-               . TL.toStrict
-               . TL.decodeUtf8
-               . B.toLazyByteString
+    (surround, alternative, ent) = case roAttributeSurround opts of
+        SurroundSingleQuote -> ("'" , "\"", "&apos;")
+        SurroundDoubleQuote -> ("\"", "'" ,  "&quot;")

--- a/test/src/Text/XmlHtml/DocumentTests.hs
+++ b/test/src/Text/XmlHtml/DocumentTests.hs
@@ -286,4 +286,4 @@ useDoubleQuoteAttrs = do
             . parseHTML "test"
     assertEqual "plain attr" (rndr tmpl1) (Right "<p div=\"tester\"></p>")
     assertEqual "plain attr" (rndr tmpl2) (Right "<p div=\"tes'er\"></p>")
-    assertEqual "plain attr" (rndr tmpl3) (Right "<p div='tes&quot;er'></p>")
+    assertEqual "plain attr" (rndr tmpl3) (Right "<p div=\"tes&quot;er\"></p>")

--- a/test/src/Text/XmlHtml/DocumentTests.hs
+++ b/test/src/Text/XmlHtml/DocumentTests.hs
@@ -282,8 +282,8 @@ useDoubleQuoteAttrs = do
         tmpl3 = "<p div='tes\"er'></p>"
         rndr  =
             fmap (B.toLazyByteString . renderWithOptions
-            (defaultRenderOptions { attributeSurround = SurroundDoubleQuote}))
+            (defaultRenderOptions { roAttributeSurround = SurroundDoubleQuote}))
             . parseHTML "test"
     assertEqual "plain attr" (rndr tmpl1) (Right "<p div=\"tester\"></p>")
     assertEqual "plain attr" (rndr tmpl2) (Right "<p div=\"tes'er\"></p>")
-    assertEqual "plain attr" (rndr tmpl3) (Right "<p div=\"tes&quot;er\"></p>")
+    assertEqual "plain attr" (rndr tmpl3) (Right "<p div='tes\"er'></p>")

--- a/test/src/Text/XmlHtml/OASISTest.hs
+++ b/test/src/Text/XmlHtml/OASISTest.hs
@@ -160,7 +160,7 @@ oasisRerender :: String -> Assertion
 oasisRerender name = do
     src         <- B.readFile name
     let Right d  = parseXML "" src
-    let src2     = toStrict' $ toLazyByteString (render d) :: B.ByteString
+    let src2     = toStrict' . toLazyByteString $ render d
     let Right d2 = parseXML "" src2
     assertEqual ("rerender " ++ name) d d2
 
@@ -187,6 +187,6 @@ hOasisRerender :: String -> Assertion
 hOasisRerender name = do
     src         <- B.readFile name
     let Right d  = parseHTML "" src
-    let src2     = toStrict' $ toLazyByteString (render d)
+    let src2     = toStrict' . toLazyByteString $ render d
     let Right d2 = parseHTML "" src2
     assertEqual ("rerender " ++ name) d d2

--- a/test/src/Text/XmlHtml/OASISTest.hs
+++ b/test/src/Text/XmlHtml/OASISTest.hs
@@ -2,11 +2,15 @@
 
 module Text.XmlHtml.OASISTest (testsOASIS) where
 
-import           Blaze.ByteString.Builder
-import           Control.Applicative
-import           Control.Monad
+import           Control.Applicative ((<*>))
+import           Data.ByteString.Builder
+import qualified Data.ByteString.Lazy as BSL
+import           Data.Foldable (forM_)
+import           Data.Functor ((<$>))
+import           Data.Traversable (forM)
 import qualified Data.ByteString as B
 import           Data.Maybe
+import           Data.Monoid (mconcat)
 import qualified Data.Text as T
 import           System.Directory
 import           Test.Framework
@@ -31,6 +35,12 @@ import           Text.XmlHtml
 --
 -- For tests that should succeed as XML but not HTML, or vice versa, files
 -- can be named /filename/@.xml.correct@, and so on (all 4 combinations).
+
+
+-- We need this as long as we support bytestring versions
+-- that don't export BSL.toStrict (ghc-7.4 and older)
+toStrict' :: BSL.ByteString -> B.ByteString
+toStrict' = mconcat . BSL.toChunks
 
 testsOASIS :: [Test]
 testsOASIS = [
@@ -150,7 +160,7 @@ oasisRerender :: String -> Assertion
 oasisRerender name = do
     src         <- B.readFile name
     let Right d  = parseXML "" src
-    let src2     = toByteString (render d)
+    let src2     = toStrict' $ toLazyByteString (render d) :: B.ByteString
     let Right d2 = parseXML "" src2
     assertEqual ("rerender " ++ name) d d2
 
@@ -177,7 +187,6 @@ hOasisRerender :: String -> Assertion
 hOasisRerender name = do
     src         <- B.readFile name
     let Right d  = parseHTML "" src
-    let src2     = toByteString (render d)
+    let src2     = toStrict' $ toLazyByteString (render d)
     let Right d2 = parseHTML "" src2
     assertEqual ("rerender " ++ name) d d2
-

--- a/test/src/Text/XmlHtml/Tests.hs
+++ b/test/src/Text/XmlHtml/Tests.hs
@@ -6,7 +6,7 @@ module Text.XmlHtml.Tests (tests) where
 import           Blaze.ByteString.Builder
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
-import           Data.Monoid
+import           Data.Monoid (mappend, mempty)
 import           Data.String
 import           Data.Text ()                  -- for string instance
 import qualified Data.Text.Encoding as T
@@ -17,7 +17,6 @@ import           Text.Blaze
 import           Text.Blaze.Html
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
-import qualified Text.Blaze.Internal as H
 import           Text.Blaze.Renderer.XmlHtml
 import           Text.XmlHtml
 import           Text.XmlHtml.CursorTests
@@ -742,21 +741,21 @@ hSingleQuoteInAttr =
     toByteString (render (HtmlDocument UTF8 Nothing [
         Element "foo" [("bar", "test\'ing")] []
         ]))
-    == "<foo bar=\"test\'ing\"></foo>"
+    == "<foo bar='test&apos;ing'></foo>"
 
 hDoubleQuoteInAttr :: Bool
 hDoubleQuoteInAttr =
     toByteString (render (HtmlDocument UTF8 Nothing [
         Element "foo" [("bar", "test\"ing")] []
         ]))
-    == "<foo bar=\'test\"ing\'></foo>"
+    == "<foo bar='test\"ing'></foo>"
 
 hBothQuotesInAttr :: Bool
 hBothQuotesInAttr =
     toByteString (render (HtmlDocument UTF8 Nothing [
-        Element "foo" [("bar", "test\'\"ing")] []
+        Element "foo" [("bar", "test'\"ing")] []
         ]))
-    == "<foo bar=\"test\'&quot;ing\"></foo>"
+    == "<foo bar='test&apos;\"ing'></foo>"
 
 
 ------------------------------------------------------------------------------
@@ -855,7 +854,7 @@ renderHTMLEmptyAttr2 =
     toByteString (render (HtmlDocument UTF8 Nothing [
         Element "a" [("href", "")] []
         ]))
-    == "<a href=\"\"></a>"
+    == "<a href=''></a>"
 
 renderHTMLAmpAttr1 :: Bool
 renderHTMLAmpAttr1 =

--- a/test/src/Text/XmlHtml/Tests.hs
+++ b/test/src/Text/XmlHtml/Tests.hs
@@ -8,7 +8,7 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
 import           Data.Monoid (mappend, mempty)
 import           Data.String
-import           Data.Text ()                  -- for string instance
+import           Data.Text (Text)
 import qualified Data.Text.Encoding as T
 import           Test.Framework
 import           Test.Framework.Providers.HUnit
@@ -583,21 +583,21 @@ utf8Decl = T.encodeUtf8 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 singleQuoteInSysID :: Bool
 singleQuoteInSysID =
     toByteString (render (XmlDocument UTF8
-        (Just (DocType "html" (System "test\'ing") NoInternalSubset))
+        (Just (DocType "html" (System "test'ing") NoInternalSubset))
         []))
-    == utf8Decl `B.append` "<!DOCTYPE html SYSTEM \"test\'ing\">\n"
+    == utf8Decl `B.append` "<!DOCTYPE html SYSTEM \"test'ing\">\n"
 
 doubleQuoteInSysID :: Bool
 doubleQuoteInSysID =
     toByteString (render (XmlDocument UTF8
         (Just (DocType "html" (System "test\"ing") NoInternalSubset))
         []))
-    == utf8Decl `B.append` "<!DOCTYPE html SYSTEM \'test\"ing\'>\n"
+    == utf8Decl `B.append` "<!DOCTYPE html SYSTEM 'test\"ing'>\n"
 
 bothQuotesInSysID :: Bool
 bothQuotesInSysID = isBottom $
     toByteString (render (XmlDocument UTF8
-        (Just (DocType "html" (System "test\"\'ing") NoInternalSubset))
+        (Just (DocType "html" (System "test\"'ing") NoInternalSubset))
         []))
 
 doubleQuoteInPubID :: Bool
@@ -628,23 +628,23 @@ renderEmptyText =
 singleQuoteInAttr :: Bool
 singleQuoteInAttr =
     toByteString (render (XmlDocument UTF8 Nothing [
-        Element "foo" [("bar", "test\'ing")] []
+        Element "foo" [("bar", "test'ing")] []
         ]))
-    == utf8Decl `B.append` "<foo bar=\"test\'ing\"/>"
+    == utf8Decl `B.append` "<foo bar=\"test'ing\"/>"
 
 doubleQuoteInAttr :: Bool
 doubleQuoteInAttr =
     toByteString (render (XmlDocument UTF8 Nothing [
         Element "foo" [("bar", "test\"ing")] []
         ]))
-    == utf8Decl `B.append` "<foo bar=\'test\"ing\'/>"
+    == utf8Decl `B.append` "<foo bar='test\"ing'/>"
 
 bothQuotesInAttr :: Bool
 bothQuotesInAttr =
     toByteString (render (XmlDocument UTF8 Nothing [
-        Element "foo" [("bar", "test\'\"ing")] []
+        Element "foo" [("bar", "test'\"ing")] []
         ]))
-    == utf8Decl `B.append` "<foo bar=\"test\'&quot;ing\"/>"
+    == utf8Decl `B.append` "<foo bar=\"test'&quot;ing\"/>"
 
 ndashEscapesInLatin :: Bool
 ndashEscapesInLatin =
@@ -694,21 +694,21 @@ hRenderByteOrderMark =
 hSingleQuoteInSysID :: Bool
 hSingleQuoteInSysID =
     toByteString (render (HtmlDocument UTF8
-        (Just (DocType "html" (System "test\'ing") NoInternalSubset))
+        (Just (DocType "html" (System "test'ing") NoInternalSubset))
         []))
-    == "<!DOCTYPE html SYSTEM \"test\'ing\">\n"
+    == "<!DOCTYPE html SYSTEM \"test'ing\">\n"
 
 hDoubleQuoteInSysID :: Bool
 hDoubleQuoteInSysID =
     toByteString (render (HtmlDocument UTF8
         (Just (DocType "html" (System "test\"ing") NoInternalSubset))
         []))
-    == "<!DOCTYPE html SYSTEM \'test\"ing\'>\n"
+    == "<!DOCTYPE html SYSTEM 'test\"ing'>\n"
 
 hBothQuotesInSysID :: Bool
 hBothQuotesInSysID = isBottom $
     toByteString (render (HtmlDocument UTF8
-        (Just (DocType "html" (System "test\"\'ing") NoInternalSubset))
+        (Just (DocType "html" (System "test\"'ing") NoInternalSubset))
         []))
 
 hDoubleQuoteInPubID :: Bool
@@ -739,9 +739,9 @@ hRenderEmptyText =
 hSingleQuoteInAttr :: Bool
 hSingleQuoteInAttr =
     toByteString (render (HtmlDocument UTF8 Nothing [
-        Element "foo" [("bar", "test\'ing")] []
+        Element "foo" [("bar", "test'ing")] []
         ]))
-    == "<foo bar='test&apos;ing'></foo>"
+    == "<foo bar=\"test'ing\"></foo>"
 
 hDoubleQuoteInAttr :: Bool
 hDoubleQuoteInAttr =
@@ -782,7 +782,11 @@ htmlRenderingQuirkTests = [
     testIt "renderHTMLQRawMult     " renderHTMLQRawMult,
     testIt "renderHTMLQRaw2        " renderHTMLQRaw2,
     testIt "renderHTMLQRaw3        " renderHTMLQRaw3,
-    testIt "renderHTMLQRaw4        " renderHTMLQRaw4
+    testIt "renderHTMLQRaw4        " renderHTMLQRaw4,
+    testCase "singleAlways           " singleAlways,
+    testCase "doubleAlways           " doubleAlways,
+    testCase "singleAvoidEscaping    " singleAvoidEscaping,
+    testCase "doubleAvoidEscaping    " doubleAvoidEscaping
     ]
 
 renderHTMLVoid :: Bool
@@ -790,7 +794,7 @@ renderHTMLVoid =
     toByteString (render (HtmlDocument UTF8 Nothing [
         Element "img" [("src", "foo")] []
         ]))
-    == "<img src=\'foo\' />"
+    == "<img src='foo' />"
 
 renderHTMLVoid2 :: Bool
 renderHTMLVoid2 = isBottom $
@@ -805,7 +809,7 @@ renderHTMLRaw =
             TextNode "<testing>/&+</foo>"
             ]
         ]))
-    == "<script type=\'text/javascript\'><testing>/&+</foo></script>"
+    == "<script type='text/javascript'><testing>/&+</foo></script>"
 
 renderHTMLRawMult :: Bool
 renderHTMLRawMult =
@@ -815,7 +819,7 @@ renderHTMLRawMult =
             TextNode "bar"
             ]
         ]))
-    == "<script type=\'text/javascript\'>foobar</script>"
+    == "<script type='text/javascript'>foobar</script>"
 
 renderHTMLRaw2 :: Bool
 renderHTMLRaw2 = isBottom $
@@ -860,26 +864,26 @@ renderHTMLAmpAttr1 :: Bool
 renderHTMLAmpAttr1 =
     toByteString (render (HtmlDocument UTF8 Nothing [
         Element "body" [("foo", "a & b")] [] ]))
-    == "<body foo=\'a & b\'></body>"
+    == "<body foo='a & b'></body>"
 
 renderHTMLAmpAttr2 :: Bool
 renderHTMLAmpAttr2 =
     toByteString (render (HtmlDocument UTF8 Nothing [
         Element "body" [("foo", "a &amp; b")] [] ]))
-    == "<body foo=\'a &amp;amp; b\'></body>"
+    == "<body foo='a &amp;amp; b'></body>"
 
 renderHTMLAmpAttr3 :: Bool
 renderHTMLAmpAttr3 =
     toByteString (render (HtmlDocument UTF8 Nothing [
         Element "body" [("foo", "a &#x65; b")] [] ]))
-    == "<body foo=\'a &amp;#x65; b\'></body>"
+    == "<body foo='a &amp;#x65; b'></body>"
 
 renderHTMLQVoid :: Bool
 renderHTMLQVoid =
     toByteString (render (HtmlDocument UTF8 Nothing [
         Element "foo:img" [("src", "foo")] []
         ]))
-    == "<foo:img src=\'foo\' />"
+    == "<foo:img src='foo' />"
 
 renderHTMLQVoid2 :: Bool
 renderHTMLQVoid2 = isBottom $
@@ -894,7 +898,7 @@ renderHTMLQRaw =
             TextNode "<testing>/&+</foo>"
             ]
         ]))
-    == "<foo:script type=\'text/javascript\'><testing>/&+</foo></foo:script>"
+    == "<foo:script type='text/javascript'><testing>/&+</foo></foo:script>"
 
 renderHTMLQRawMult :: Bool
 renderHTMLQRawMult =
@@ -904,7 +908,7 @@ renderHTMLQRawMult =
             TextNode "bar"
             ]
         ]))
-    == "<foo:script type=\'text/javascript\'>foobar</foo:script>"
+    == "<foo:script type='text/javascript'>foobar</foo:script>"
 
 renderHTMLQRaw2 :: Bool
 renderHTMLQRaw2 = isBottom $
@@ -930,6 +934,46 @@ renderHTMLQRaw4 = isBottom $
             TextNode "pt>"
             ]
         ]))
+
+renderToByteString :: RenderOptions -> ByteString
+renderToByteString opts = toByteString (renderWithOptions opts document)
+  where
+    attrs :: [(Text, Text)]
+    attrs = [("single", "'"), ("double", "\""), ("both", "'\"")]
+    document :: Document
+    document = HtmlDocument UTF8 Nothing [Element "div" attrs []]
+
+singleAlways :: Assertion
+singleAlways =
+    assertEqual "singleAlways"
+                (renderToByteString (RenderOptions SurroundSingleQuote
+                                                   AttrResolveByEscape
+                                                   Nothing))
+                "<div single='&apos;' double='\"' both='&apos;\"'></div>"
+
+doubleAlways :: Assertion
+doubleAlways =
+    assertEqual "doubleAlways"
+                (renderToByteString (RenderOptions SurroundDoubleQuote
+                                                   AttrResolveByEscape
+                                                   Nothing))
+                "<div single=\"'\" double=\"&quot;\" both=\"'&quot;\"></div>"
+
+singleAvoidEscaping :: Assertion
+singleAvoidEscaping =
+    assertEqual "singleAvoidEscaping"
+                (renderToByteString (RenderOptions SurroundSingleQuote
+                                                   AttrResolveAvoidEscape
+                                                   Nothing))
+                "<div single=\"'\" double='\"' both='&apos;\"'></div>"
+
+doubleAvoidEscaping :: Assertion
+doubleAvoidEscaping =
+    assertEqual "doubleAvoidEscaping"
+                (renderToByteString (RenderOptions SurroundDoubleQuote
+                                                   AttrResolveAvoidEscape
+                                                   Nothing))
+                "<div single=\"'\" double='\"' both=\"'&quot;\"></div>"
 
 
 ------------------------------------------------------------------------------
@@ -996,6 +1040,3 @@ blazeTestEmpty = renderHtmlNodes mempty == []
 
 selectCustom :: Html
 selectCustom = H.select ! H.customAttribute "dojoType" "select" $ (mappend "foo " "bar")
-
-
-

--- a/test/src/Text/XmlHtml/Tests.hs
+++ b/test/src/Text/XmlHtml/Tests.hs
@@ -644,7 +644,7 @@ bothQuotesInAttr =
     toByteString (render (XmlDocument UTF8 Nothing [
         Element "foo" [("bar", "test'\"ing")] []
         ]))
-    == utf8Decl `B.append` "<foo bar=\"test'&quot;ing\"/>"
+    == utf8Decl `B.append` "<foo bar='test&apos;\"ing'/>"
 
 ndashEscapesInLatin :: Bool
 ndashEscapesInLatin =

--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -824,6 +824,7 @@ Library
                        blaze-html           >= 0.5   && < 0.9,
                        blaze-markup         >= 0.5   && < 0.8,
                        bytestring           >= 0.9   && < 0.11,
+                       bytestring-builder   >= 0.10.4.0.2 && < 0.11,
                        containers           >= 0.3   && < 0.6,
                        parsec               >= 3.1.2 && < 3.2,
                        text                 >= 0.11  && < 1.3,
@@ -853,10 +854,13 @@ Test-suite testsuite
     blaze-markup,
     bytestring,
     bytestring-builder,
+    containers,
     directory                  >= 1.0      && <1.4,
+    parsec,
     test-framework             >= 0.8.0.3  && <0.9,
     test-framework-hunit       >= 0.3      && <0.4,
     text,
+    unordered-containers,
     xmlhtml
 
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -threaded

--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -854,13 +854,10 @@ Test-suite testsuite
     blaze-markup,
     bytestring,
     bytestring-builder,
-    containers,
     directory                  >= 1.0      && <1.4,
-    parsec,
     test-framework             >= 0.8.0.3  && <0.9,
     test-framework-hunit       >= 0.3      && <0.4,
     text,
-    unordered-containers,
     xmlhtml
 
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -threaded


### PR DESCRIPTION
@mightybyte The 'strictAttributeSurrounds` branch (which was merged into `master` today) changes rendering behavior when an attribute value has quotes inside it that conflict with the surrounding quotes.

We used to change the external quotes when an internal quote conflicted (possibly overriding the user's preference for outer quote type).

Now we always respect the user's preferred quote type (which defaults to `'`), and we escape inner quotes if they conflict with the outer ones.

This PR just updates the test suite for that behavior and fixes some broken imports on older ghc versions.