### PR TITLE
Bump upper bound for hspec.

### DIFF
--- a/xmlhtml.cabal
+++ b/xmlhtml.cabal
@@ -858,7 +858,7 @@ Test-suite testsuite
     bytestring-builder,
     containers,
     directory                  >= 1.0      && <1.4,
-    hspec                      >= 2.4      && <2.5,
+    hspec                      >= 2.4      && <2.6,
     text,
     unordered-containers,
     xmlhtml


### PR DESCRIPTION
Tests pass with 2.5.5